### PR TITLE
Automatically create required files

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,6 +1,7 @@
 var fs        = require('fs');
 var net       = require('net');
 var events    = require('events');
+var path      = require('path');
 
 var irc = {};
 
@@ -10,14 +11,22 @@ var config_file = config_path + '/config';
 var user_file   = config_path + '/users.json';
 var plugin_dir  = config_path + '/plugins/';
 
+fs.mkdirSync(config_path, 0755);
+fs.mkdirSync(plugin_dir, 0755);
+
+var exists = path.existsSync(config_file);
+if(!exists) {
+  fs.openSync(config_file, 'w+');
+  fs.writeFileSync(config_file, fs.readFileSync('./config.sample'));
+}
 irc.config = JSON.parse(fs.readFileSync(config_file));
 
-fs.readFile(user_file, function(err, data) {
-  if (err) {
-    console.log("users.json file must exist!");
-    throw err
+path.exists(user_file, function (exists) {
+  if(!exists) {
+    fs.openSync(user_file, 'w+');
+    fs.writeFileSync(user_file, fs.readFileSync('./users.json.sample'));
   }
-  irc.users = JSON.parse(data);
+  irc.users = JSON.parse(fs.readFileSync(user_file));
 });
 
 irc.command_char = '!';

--- a/client.js
+++ b/client.js
@@ -11,8 +11,14 @@ var config_file = config_path + '/config';
 var user_file   = config_path + '/users.json';
 var plugin_dir  = config_path + '/plugins/';
 
-fs.mkdirSync(config_path, 0755);
-fs.mkdirSync(plugin_dir, 0755);
+var exists = path.existsSync(config_path);
+if (!exists) {
+  fs.mkdirSync(config_path, 0755);
+}
+var exists = path.existsSync(plugin_dir);
+if (!exists) {
+  fs.mkdirSync(plugin_dir, 0755);
+}
 
 var exists = path.existsSync(config_file);
 if(!exists) {

--- a/client.js
+++ b/client.js
@@ -16,6 +16,7 @@ fs.mkdirSync(plugin_dir, 0755);
 
 var exists = path.existsSync(config_file);
 if(!exists) {
+  console.log('Creating a new config file');
   fs.openSync(config_file, 'w+');
   fs.writeFileSync(config_file, fs.readFileSync('./config.sample'));
 }
@@ -23,6 +24,7 @@ irc.config = JSON.parse(fs.readFileSync(config_file));
 
 path.exists(user_file, function (exists) {
   if(!exists) {
+    console.log('Creating a new users.json file');
     fs.openSync(user_file, 'w+');
     fs.writeFileSync(user_file, fs.readFileSync('./users.json.sample'));
   }


### PR DESCRIPTION
The configuration files and folders the bot requires should be automatically created if they do not exist instead of just failing.
