### PR TITLE
!learn, !forget and !know implementation

### DIFF
--- a/client.js
+++ b/client.js
@@ -441,6 +441,11 @@ irc.emitter.on('version', function (act) {
 });
 
 if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
+  var containsPhrase = function (msg, phrase) {
+    phrase = phrase.replace(/%nick/gi, irc.config.nick);
+    return msg.indexOf(phrase) !== -1;
+  };
+
   if (!path.existsSync(config_path + '/know.json'))
     fs.writeFileSync(config_path + '/know.json', '{ "action": { }, "regular": { } }', 'utf8');
   var know_dict = JSON.parse(fs.readFileSync(config_path + '/know.json', 'utf8'));
@@ -458,12 +463,12 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
         msg.substring(msg.length - 1, msg.length) === '\u0001') {
       msg = msg.substring(8, msg.length - 1);
       for (var valuea1 in know_dict.action)
-        if (msg.indexOf(valuea1) !== -1)
+        if (containsPhrase(msg, valuea1))
           irc.privmsg(source, know_dict.action[valuea1].response);
     } else if (msg.substring(0, irc.command_char.length + 6) !== irc.command_char + 'forget' &&
         msg.substring(0, irc.command_char.length + 5) !== irc.command_char + 'learn')
       for (var valuer1 in know_dict.regular)
-        if (msg.indexOf(valuer1) !== -1)
+        if (containsPhrase(msg, valuer1))
           irc.privmsg(source, know_dict.regular[valuer1].response);
   });
 

--- a/client.js
+++ b/client.js
@@ -555,28 +555,28 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
       if (is_admin) {
         var input = act.params.join(' ').split('"');
         if (input.length < 5)
-          irc.privmsg(act.source, 'Usage: ' + irc.command_char + 'learn "LISTENER" "RESPONSE"');
+          irc.privmsg(act.nick, 'USAGE: ' + irc.command_char + 'learn "LISTENER" "RESPONSE"');
         else {
           var listener = input[1];
           var response = input[3];
           if (listener === '')
-            irc.privmsg(act.source, 'Unable to add an empty listener.');
+            irc.privmsg(act.nick, 'Unable to add an empty listener.');
           else if (response === '')
-            irc.privmsg(act.source, 'Unable to add an empty response.');
+            irc.privmsg(act.nick, 'Unable to add an empty response.');
           else {
             if (listener.substring(0, 4) === '/me ') {
               know_dict.action[listener.substring(4, listener.length).toLowerCase()] = { "response": response, "hidden": "false" };
-              irc.privmsg(act.source, 'Added the "' + parsePhrase(listener) +  '" listener.');
+              irc.privmsg(act.nick, 'Added the "' + parsePhrase(listener) +  '" listener.');
               fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
             } else {
               know_dict.regular[listener.toLowerCase()] = { "response": response, "hidden": "false" };
-              irc.privmsg(act.source, 'Added the "' + parsePhrase(listener) + '" listener.');
+              irc.privmsg(act.nick, 'Added the "' + parsePhrase(listener) + '" listener.');
               fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
             }
           }
         }
       } else
-        irc.privmsg(act.source, 'Not authorized to modify responses.');
+        irc.privmsg(act.nick, 'Not authorized to modify responses.');
     });
   });
 
@@ -585,21 +585,21 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
       if (is_admin) {
         var listener = act.params.join(' ');
         if (listener === '')
-          irc.privmsg(act.source, 'USAGE: ' + irc.command_char + 'forget LISTENER');
+          irc.privmsg(act.nick, 'USAGE: ' + irc.command_char + 'forget LISTENER');
         else {
           if (listener.substring(0, 4) === '/me ' && know_dict.action[listener.substring(4, listener.length).toLowerCase()] !== undefined) {
             delete know_dict.action[listener.substring(4, listener.length).toLowerCase()];
-            irc.privmsg(act.source, 'Deleted the "' + parsePhrase(listener) +  '" listener.');
+            irc.privmsg(act.nick, 'Deleted the "' + parsePhrase(listener) +  '" listener.');
             fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
           } else if (know_dict.regular[listener.toLowerCase()] !== undefined) {
             delete know_dict.regular[listener.toLowerCase()];
-            irc.privmsg(act.source, 'Deleted the "' + parsePhrase(listener) + '" listener.');
+            irc.privmsg(act.nick, 'Deleted the "' + parsePhrase(listener) + '" listener.');
             fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
           } else
-            irc.privmsg(act.source, 'Could not find the "' + parsePhrase(listener) + '" listener.');
+            irc.privmsg(act.nick, 'Could not find the "' + parsePhrase(listener) + '" listener.');
         }
       } else
-        irc.privmsg(act.source, 'Not authorized to modify responses.');
+        irc.privmsg(act.nick, 'Not authorized to modify responses.');
     });
   });
 
@@ -612,7 +612,7 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
       if (know_dict.regular[valuer2].hidden !== 'true')
         output[0] += '\'' + parsePhrase(valuer2) + '\', ';
     if (output[0] === 'Responses known to: ')
-      irc.privmsg(act.source, 'No known responses.');
+      irc.privmsg(act.nick, 'No known responses.');
     else {
       var loop = true;
       while (loop) {
@@ -626,14 +626,21 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
               output[parseInt(i, 10) + 1] = outArr.splice(outArr.length - 1, 1) + ', ' + output[parseInt(i, 10) + 1];
               output[i] = outArr.join(', ');
             }
-            output[parseInt(i, 10) + 1] = '...' + output[parseInt(i, 10) + 1].slice(0, -2);
+            output[parseInt(i, 10) + 1] = '...' + output[parseInt(i, 10) + 1].slice(0, -4);
             output[i] += '...';
             loop = true;
           }
         }
       }
-      for (var i2 = 0; i2 < output.length && i2 < 3; i2++)
-        irc.privmsg(act.source, output[i2]);
+      irc.privmsg(act.nick, output[0]);
+      var crntMsg = 0;
+      var interid = setInterval(function () {
+        crntMsg++;
+        if (crntMsg < output.length)
+          irc.privmsg(act.nick, output[crntMsg]);
+        else
+          clearInterval(interid);
+      }, 3000);
     }
   });
 }

--- a/client.js
+++ b/client.js
@@ -443,7 +443,7 @@ irc.emitter.on('version', function (act) {
 if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
   var parsePhrase = function (phrase) {
     phrase = phrase.replace(/%nick/gi, irc.config.nick);
-    return phrase;
+    return phrase.toLowerCase();
   };
 
   if (!path.existsSync(config_path + '/know.json'))

--- a/client.js
+++ b/client.js
@@ -454,7 +454,7 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
       var new_dict = JSON.parse(fs.readFileSync(config_path + '/know.json', 'utf8'));
       know_dict = new_dict;
     } catch (err) {
-      console.log('WARNING: Unable to update the know dictionary. Error: ' + err.message);
+      console.log('WARNING: Unable to update the "know" dictionary. Error: ' + err.message);
     }
   }, 20000);
 
@@ -540,8 +540,20 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
         output += '\'' + parsePhrase(valuer2) + '\', ';
     if (output === 'Responses known to: ')
       irc.privmsg(act.source, 'No known responses.');
-    else
-      irc.privmsg(act.source, output.substring(0, output.length - 2));
+    else {
+      output = output.substring(0, output.length - 2);
+      if (output.length > 400) {
+        var cuts = 0;
+        while (output.length > 390) {
+          var outArr = output.split(', ');
+          outArr.splice(outArr.length - 1, 1);
+          output = outArr.join(', ');
+          cuts++;
+        }
+        output += ' and ' + cuts + ' more';
+      }
+      irc.privmsg(act.source, output);
+    }
   });
 }
 

--- a/client.js
+++ b/client.js
@@ -497,20 +497,23 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
   var msgContainsPhrase = function (msg, phrase) {
     phrase = phrase.replace(/%nick/gi, irc.config.nick);
     if (phrase.indexOf('%re') !== -1) {
-      var passCheck = true;
       while (phrase.indexOf('%re') !== -1) {
         var phrase1 = phrase.slice(0, phrase.indexOf('%re'));
         var phrasex = phrase.slice(phrase.indexOf('%re') + 3);
         var phrasere = phrasex.slice(0, phrasex.indexOf('%re'));
         var phrase2 = phrasex.slice(phrasex.indexOf('%re') + 3);
-        var regexp = phrasere.split('/').length > 1 ? new RegExp(phrasere.split('/')[1], phrasere.split('/')[2]) : new RegExp(phrasere);
-        phrase = phrase1 + phrase2;
-        if (msg.indexOf(phrase1) === -1 || msg.indexOf(phrase2) === -1 || msg.search(regexp) === -1) {
-          passCheck = false;
-          break;
+        try {
+          var regexp = (phrasere.split('/').length > 1) ? (new RegExp(phrasere.split('/')[1], phrasere.split('/')[2])) : (new RegExp(phrasere, 'i'));
+          phrase = phrase1 + phrase2;
+          if (msg.indexOf(phrase1.trim()) === -1 || msg.indexOf(phrase2.trim()) === -1 || msg.search(regexp) === -1) {
+            return false;
+          }
+        } catch (err) {
+          console.log('WARNING: Unable to parse \'' + phrasere + '\' into a RegExp. Error: ' + err.message);
+          return false;
         }
       }
-      return passCheck;
+      return true;
     } else {
       return msg.indexOf(phrase.toLowerCase()) !== -1;
     }

--- a/client.js
+++ b/client.js
@@ -604,28 +604,36 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
   });
 
   irc.emitter.on('know', function (act) {
-    var output = 'Responses known to: ';
+    var output = [ 'Responses known to: ' ];
     for (var valuea2 in know_dict.action)
       if (know_dict.action[valuea2].hidden !== 'true')
-        output += '\'/me ' + parsePhrase(valuea2) + '\', ';
+        output[0] += '\'/me ' + parsePhrase(valuea2) + '\', ';
     for (var valuer2 in know_dict.regular)
       if (know_dict.regular[valuer2].hidden !== 'true')
-        output += '\'' + parsePhrase(valuer2) + '\', ';
-    if (output === 'Responses known to: ')
+        output[0] += '\'' + parsePhrase(valuer2) + '\', ';
+    if (output[0] === 'Responses known to: ')
       irc.privmsg(act.source, 'No known responses.');
     else {
-      output = output.substring(0, output.length - 2);
-      if (output.length > 400) {
-        var cuts = 0;
-        while (output.length > 390) {
-          var outArr = output.split(', ');
-          outArr.splice(outArr.length - 1, 1);
-          output = outArr.join(', ');
-          cuts++;
+      var loop = true;
+      while (loop) {
+        loop = false;
+        for (var i in output) {
+          if (output[i].length > 400) {
+            if (output[parseInt(i, 10) + 1] === undefined)
+              output[parseInt(i, 10) + 1] = '';
+            while (output[i].length > 397) {
+              var outArr = output[i].split(', ');
+              output[parseInt(i, 10) + 1] = outArr.splice(outArr.length - 1, 1) + ', ' + output[parseInt(i, 10) + 1];
+              output[i] = outArr.join(', ');
+            }
+            output[parseInt(i, 10) + 1] = '...' + output[parseInt(i, 10) + 1].slice(0, -2);
+            output[i] += '...';
+            loop = true;
+          }
         }
-        output += ' and ' + cuts + ' more';
       }
-      irc.privmsg(act.source, output);
+      for (var i2 = 0; i2 < output.length && i2 < 3; i2++)
+        irc.privmsg(act.source, output[i2]);
     }
   });
 }

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -542,21 +542,31 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
       if (is_admin) {
         var input = act.params.join(' ').split('"');
         if (input.length < 5)
-          irc.privmsg(act.nick, 'USAGE: ' + irc.command_char + 'learn "LISTENER" "RESPONSE"');
+          irc.privmsg(act.nick, 'USAGE: ' + irc.command_char + 'learn "LISTENER" "RESPONSE" [--flags]');
         else {
           var listener = input[1];
           var response = input[3];
+          var flags = input[4].trim().split(' ');
+          var dict_entry = { "response": response, "hidden": "false" };
+          for (var i in flags)
+            switch (flags[i]) {
+            case '--hidden':
+              dict_entry.hidden = 'true';
+              break;
+            default:
+              break;
+            }
           if (listener === '')
             irc.privmsg(act.nick, 'Unable to add an empty listener.');
           else if (response === '')
             irc.privmsg(act.nick, 'Unable to add an empty response.');
           else {
             if (listener.substring(0, 4) === '/me ') {
-              know_dict.action[listener.substring(4, listener.length).toLowerCase()] = { "response": response, "hidden": "false" };
+              know_dict.action[listener.substring(4, listener.length)] = dict_entry;
               irc.privmsg(act.nick, 'Added the "' + parsePhrase(listener) +  '" listener.');
               fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
             } else {
-              know_dict.regular[listener.toLowerCase()] = { "response": response, "hidden": "false" };
+              know_dict.regular[listener] = dict_entry;
               irc.privmsg(act.nick, 'Added the "' + parsePhrase(listener) + '" listener.');
               fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
             }
@@ -574,12 +584,12 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
         if (listener === '')
           irc.privmsg(act.nick, 'USAGE: ' + irc.command_char + 'forget LISTENER');
         else {
-          if (listener.substring(0, 4) === '/me ' && know_dict.action[listener.substring(4, listener.length).toLowerCase()] !== undefined) {
-            delete know_dict.action[listener.substring(4, listener.length).toLowerCase()];
+          if (listener.substring(0, 4) === '/me ' && know_dict.action[listener.substring(4, listener.length)] !== undefined) {
+            delete know_dict.action[listener.substring(4, listener.length)];
             irc.privmsg(act.nick, 'Deleted the "' + parsePhrase(listener) +  '" listener.');
             fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
-          } else if (know_dict.regular[listener.toLowerCase()] !== undefined) {
-            delete know_dict.regular[listener.toLowerCase()];
+          } else if (know_dict.regular[listener] !== undefined) {
+            delete know_dict.regular[listener];
             irc.privmsg(act.nick, 'Deleted the "' + parsePhrase(listener) + '" listener.');
             fs.writeFile(config_path + '/know.json', JSON.stringify(know_dict, null, 2), 'utf8');
           } else

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -548,7 +548,7 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
   });
 
   irc.emitter.on('learn', function (act) {
-    irc.check_level(act.nick, 'admin', function (is_admin) {
+    irc.check_level(act.nick, act.host, 'admin', function (is_admin) {
       if (is_admin) {
         var input = act.params.join(' ').split('"');
         if (input.length < 5)
@@ -591,7 +591,7 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
   });
 
   irc.emitter.on('forget', function (act) {
-    irc.check_level(act.nick, 'admin', function (is_admin) {
+    irc.check_level(act.nick, act.host, 'admin', function (is_admin) {
       if (is_admin) {
         var listener = act.params.join(' ');
         if (listener === '')

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -477,11 +477,12 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
   var parsePhrase = function (phrase) {
     phrase = phrase.replace(/%nick/gi, irc.config.nick);
     phrase = phrase.replace(/%re/gi, '');
-    return phrase.toLowerCase();
+    return phrase;
   };
 
   var msgContainsPhrase = function (msg, phrase) {
     phrase = phrase.replace(/%nick/gi, irc.config.nick);
+    phrase = phrase.toLowerCase();
     if (phrase.indexOf('%re') !== -1) {
       while (phrase.indexOf('%re') !== -1) {
         var phrase1 = phrase.slice(0, phrase.indexOf('%re'));
@@ -501,7 +502,7 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
       }
       return true;
     } else {
-      return msg.indexOf(phrase.toLowerCase()) !== -1;
+      return msg.indexOf(phrase) !== -1;
     }
   };
 

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -480,7 +480,7 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
     return phrase;
   };
 
-  var msgContainsPhrase = function (msg, phrase) {
+  var msgContainsPhrase = function (msg, phrase, strict) {
     phrase = phrase.replace(/%nick/gi, irc.config.nick);
     phrase = phrase.toLowerCase();
     if (phrase.indexOf('%re') !== -1) {
@@ -495,14 +495,17 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
           if (msg.indexOf(phrase1.trim()) === -1 || msg.indexOf(phrase2.trim()) === -1 || msg.search(regexp) === -1) {
             return false;
           }
+          if (strict) {
+            msg = msg.replace(phrase1.trim(), '').replace(phrase2.trim(), '').replace(regexp, '');
+          }
         } catch (err) {
           console.log('WARNING: Unable to parse \'' + phrasere + '\' into a RegExp. Error: ' + err.message);
           return false;
         }
       }
-      return true;
+      return strict ? msg.trim() === '' : true;
     } else {
-      return msg.indexOf(phrase) !== -1;
+      return strict ? msg === phrase : msg.indexOf(phrase) !== -1;
     }
   };
 
@@ -528,12 +531,12 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
         msg.substring(msg.length - 1, msg.length) === '\u0001') {
       msg = msg.substring(8, msg.length - 1);
       for (var valuea1 in know_dict.action)
-        if (msgContainsPhrase(msg, valuea1))
+        if (msgContainsPhrase(msg, valuea1, (know_dict.action[valuea1].strict === 'true')))
           irc.privmsg(source, know_dict.action[valuea1].response);
     } else if (msg.substring(0, irc.command_char.length + 6) !== irc.command_char + 'forget' &&
         msg.substring(0, irc.command_char.length + 5) !== irc.command_char + 'learn')
       for (var valuer1 in know_dict.regular)
-        if (msgContainsPhrase(msg, valuer1))
+        if (msgContainsPhrase(msg, valuer1, (know_dict.regular[valuer1].strict === 'true')))
           irc.privmsg(source, know_dict.regular[valuer1].response);
   });
 
@@ -547,11 +550,14 @@ if (process.env.IRC_NODE_ENABLE_KNOW !== 'false') {
           var listener = input[1];
           var response = input[3];
           var flags = input[4].trim().split(' ');
-          var dict_entry = { "response": response, "hidden": "false" };
+          var dict_entry = { "response": response, "hidden": "false", "strict": "false" };
           for (var i in flags)
             switch (flags[i]) {
             case '--hidden':
               dict_entry.hidden = 'true';
+              break;
+            case '--strict':
+              dict_entry.strict = 'true';
               break;
             default:
               break;


### PR DESCRIPTION
The !learn, !forget and !know commands are implemented and ready for merging into master. The current implementation on the branch is stable. This pull request is a proposed implementation of #7.

The usage of these commands is:
- `!know` -- purely to show the phrases the bot responds to.
- `!learn "PHRASE" "RESPONSE" [--flags]` -- sends out RESPONSE to the channel or private message when it sees PHRASE. the flags currently only consist of `--hidden`, which hides it from the `!know` list.
- `!forget PHRASE` -- stops sending response assigned to PHRASE.
