### PR TITLE
bin/app.js to look for uninstalled source library

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -1,3 +1,8 @@
 #!/usr/bin/env node
-var irc = require('ircnode');
+var irc;
+try {
+  irc = require(__dirname + '/../lib/ircnode.js');
+} catch (err) {
+  irc = require('ircnode');
+}
 irc.connect();


### PR DESCRIPTION
Currently the bin/app.js file only works if IRC Node has been installed. This should not be the case in my opinion, mostly for quick testing while developing. The code will first look for the uninstalled library as the point of this is to use it when available and having it look for IRC Node using `require('ircnode')` will result in it returning the installed module.
