### PR TITLE
made !seen not available through private messages

### DIFF
--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -452,18 +452,21 @@ irc.emitter.on('PRIVMSG', function (data) {
 });
 
 irc.emitter.on('seen', function (act) {
-  var nick = act.params[0] ? act.params : act.nick;
-  if (typeof irc.users[nick] === 'undefined' ||
-      typeof irc.users[nick].seen_msg === 'undefined' ||
-      typeof irc.users[nick].seen_time === 'undefined') {
-    irc.privmsg(act.source, 'Unknown nick: ' + nick);
-    return (1);
+  if (act.channel === irc.config.nick) {
+    irc.privmsg(act.source, 'As a security precaution, !seen has been deactivated for private messages. Please use the same command in a room in which the bot resides.');
+  } else {
+    var nick = act.params[0] ? act.params : act.nick;
+    if (typeof irc.users[nick] === 'undefined' ||
+        typeof irc.users[nick].seen_msg === 'undefined' ||
+        typeof irc.users[nick].seen_time === 'undefined') {
+      irc.privmsg(act.source, 'Unknown nick: ' + nick);
+      return (1);
+    }
+    var msg = irc.users[nick].seen_msg;
+    if (msg.substring(0, 7) === '\u0001ACTION')
+      msg = '***' + nick + msg.substring(7, msg.length - 1);
+    irc.privmsg(act.source, nick + ' last seen: ' + irc.users[nick].seen_time + " saying '" + msg + "' in " + irc.users[nick].seen_channel);
   }
-  var msg = irc.users[nick].seen_msg;
-  if (msg.substring(0, 7) === '\u0001ACTION')
-    msg = '***' + nick + msg.substring(7, msg.length - 1);
-  irc.privmsg(act.source, nick + ' last seen: ' + irc.users[nick].seen_time +
-              " saying '" + msg + "' in " + irc.users[nick].seen_channel);
 });
 
 irc.emitter.on('version', function (act) {


### PR DESCRIPTION
Currently the bot can be used by anyone as a spying tool. That can be simply done by calling !seen person1, !seen person2 and !seen person3 commands all the time. The bot will automatically respond by giving the newest quote it has even if the person is not in the said room.
