### PR TITLE
Authorization using hostnames

### DIFF
--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -15,6 +15,7 @@ var config_path = (process.env.IRC_NODE_PATH ||
 
 var config_file = config_path + '/config';
 var user_file   = config_path + '/users.json';
+var host_file   = config_path + '/hosts.json';
 var plugin_dir  = config_path + '/plugins/';
 var log_file    = config_path + '/bot.log';
 var lock_file   = '/tmp/ircnode.pid';
@@ -27,6 +28,7 @@ irc.userLoop = setInterval(function () {
 
 irc.config  = JSON.parse(fs.readFileSync(config_file));
 irc.users   = JSON.parse(fs.readFileSync(user_file));
+irc.hosts   = JSON.parse(fs.readFileSync(host_file));
 
 irc.reserved_words = ['PRIVMSG', 'PING', 'PART', 'JOIN', 'QUIT'];
 
@@ -141,7 +143,13 @@ path.exists(__dirname + '/.git/', function (exists) {
   }
 });
 
-irc.check_level = function (nick, level, callback) {
+irc.check_level = function (nick, host, level, callback) {
+  if (typeof irc.hosts[host] !== 'undefined')
+    if (typeof irc.hosts[host].auth !== 'undefined')
+      if (irc.auth_levels.indexOf(level) !== -1 && irc.auth_levels.indexOf(level) <= irc.auth_levels.indexOf(irc.hosts[host].auth)) {
+        callback(true);
+        return;
+      }
   if (typeof irc.users[nick] === 'undefined')
     callback(false);
   else if (typeof irc.users[nick].auth === 'undefined')
@@ -170,12 +178,12 @@ irc.check_level = function (nick, level, callback) {
     callback(false);
 };
 
-irc.is_admin = function (nick, callback) {
-  irc.check_level(nick, 'admin', callback);
+irc.is_admin = function (nick, host, callback) {
+  irc.check_level(nick, host, 'admin', callback);
 };
 
-irc.is_owner = function (nick, callback) {
-  irc.check_level(nick, 'owner', callback);
+irc.is_owner = function (nick, host, callback) {
+  irc.check_level(nick, host, 'owner', callback);
 };
 
 
@@ -377,7 +385,7 @@ fs.readdir(plugin_dir, function (err, files) {
 });
 
 irc.emitter.on('disable', function (act) {
-  irc.check_level(act.nick, 'admin', function (is_admin) {
+  irc.check_level(act.nick, act.host, 'admin', function (is_admin) {
     if (is_admin) {
       for (var p in irc.plugins) {
         if (irc.plugins[p].name === act.params[0]) {
@@ -393,7 +401,7 @@ irc.emitter.on('disable', function (act) {
 });
 
 irc.emitter.on('enable', function (act) {
-  irc.check_level(act.nick, 'admin', function (is_admin) {
+  irc.check_level(act.nick, act.host, 'admin', function (is_admin) {
     if (is_admin) {
       for (var p in irc.plugins) {
         if (irc.plugins[p].name === act.params[0] &&
@@ -425,7 +433,7 @@ irc.emitter.on('set_auth', function (act) {
     irc.privmsg(act.source, 'ERROR: Invalid parameter: ' + level);
     return (1);
   }
-  irc.check_level(act.nick, 'owner', function (is_owner) {
+  irc.check_level(act.nick, act.host, 'owner', function (is_owner) {
     if (is_owner) {
       if (nick === act.nick) {
         irc.privmsg(act.source, 'ERROR: Cannot change your own permissions!');

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -145,11 +145,10 @@ path.exists(__dirname + '/.git/', function (exists) {
 
 irc.check_level = function (nick, host, level, callback) {
   if (typeof irc.hosts[host] !== 'undefined')
-    if (typeof irc.hosts[host].auth !== 'undefined')
-      if (irc.auth_levels.indexOf(level) !== -1 && irc.auth_levels.indexOf(level) <= irc.auth_levels.indexOf(irc.hosts[host].auth)) {
-        callback(true);
-        return;
-      }
+    if (irc.auth_levels.indexOf(level) !== -1 && irc.auth_levels.indexOf(level) <= irc.auth_levels.indexOf(irc.hosts[host])) {
+      callback(true);
+      return;
+    }
   if (typeof irc.users[nick] === 'undefined')
     callback(false);
   else if (typeof irc.users[nick].auth === 'undefined')

--- a/util/install.js
+++ b/util/install.js
@@ -5,6 +5,7 @@ var isGlobal = process.env.npm_config_global
 var configPath = path.resolve(process.env[(process.platform === 'win32') ? 'USERPROFILE' : 'HOME'], '.ircnode')
 var configFile = path.resolve(configPath, 'config')
 var userFile   = path.resolve(configPath, 'users.json')
+var hostFile   = path.resolve(configPath, 'hosts.json');
 var pluginDir  = path.resolve(configPath, 'plugins/')
 
 var exists = path.existsSync(configPath)
@@ -14,7 +15,7 @@ if (!exists) {
 }
 
 var review_required = false
-;[configFile, userFile].forEach(function (file) {
+;[configFile, userFile, hostFile].forEach(function (file) {
   var exists = path.existsSync(file)
   if (!exists) {
     var sample_file = './' + path.basename(file) + '.sample'


### PR DESCRIPTION
This is a proposed solution to #40.

Entries are added to the hosts file (config_path/hosts.json) with syntax of "host": "auth_level". The bot first looks for matches inside host list and if there is a match for the host, it will not look at users.json file.

``` json
{
  "unaffiliated/thatvalterguy": "owner",
  "pdpc/supporter/active/someone": "admin",
  "example.com": "admin",
  "255.255.255.256": "admin"
}
```
