### PR TITLE
made irc.privmsg send multiple lines one by one

### DIFF
--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -191,7 +191,9 @@ irc._wrapMessage = function (target, msg) {
 };
 
 irc.privmsg  = function (target, msg) {
-  irc.send(irc._wrapMessage(target, msg));
+  msg = msg.split('\n');
+  for (var i in msg)
+    irc.send(irc._wrapMessage(target, msg[i]));
 };
 
 irc.splitcmd = function (data) {


### PR DESCRIPTION
With the current code, `Hello\nQUIT will exit` would send 'Hello' to the target and then send a QUIT with message 'will exit'. The new code would send 'Hello' and then 'QUIT will exit' to the target instead.
