### PR TITLE
Reloading plugins on file change

### DIFF
--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -304,6 +304,7 @@ irc.emitter.on('PRIVMSG', function (data) {
 global.irc = irc;
 irc.plugins = [];
 var commandsEnabled = {};
+var pluginData = {};
 function unloadPlugin(filename) {
   var ppath = path.join(plugin_dir, filename);
   if (ppath.indexOf('.js', ppath.length - 3) === -1) {
@@ -320,7 +321,7 @@ function unloadPlugin(filename) {
         irc.plugins.pop(p);
     for (var command in plugin.commands)
       irc.emitter.removeListener(command, plugin.commands[command]);
-    return plugin.store;
+    pluginData[plugin.name] = plugin.store;
   }
 }
 function loadPlugin(filename) {
@@ -328,12 +329,14 @@ function loadPlugin(filename) {
   if (ppath.indexOf('.js', ppath.length - 3) === -1) {
     console.log('Invalid plugin file: ' + filename);
   } else {
-    var oldStore = unloadPlugin(filename);
+    unloadPlugin(filename);
     var plugin = require(ppath);
     if (plugin.store === undefined)
       plugin.store = {};
-    for (var valueName in oldStore)
-      plugin.store[valueName] = oldStore[valueName];
+    if (pluginData[plugin.name] === undefined)
+      pluginData[plugin.name] = {};
+    for (var valueName in pluginData[plugin.name])
+      plugin.store[valueName] = pluginData[plugin.name][valueName];
     for (var cmd in plugin.commands) {
       if (commandsEnabled[cmd] === undefined)
         commandsEnabled[cmd] = true;

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -303,7 +303,7 @@ irc.emitter.on('PRIVMSG', function (data) {
 
 global.irc = irc;
 irc.plugins = [];
-var pluginsEnabled = {};
+var commandsEnabled = {};
 function unloadPlugin(filename) {
   var ppath = path.join(plugin_dir, filename);
   if (ppath.indexOf('.js', ppath.length - 3) === -1) {
@@ -335,9 +335,9 @@ function loadPlugin(filename) {
     for (var valueName in oldStore)
       plugin.store[valueName] = oldStore[valueName];
     for (var cmd in plugin.commands) {
-      if (pluginsEnabled[cmd] === undefined)
-        pluginsEnabled[cmd] = true;
-      if (pluginsEnabled[cmd])
+      if (commandsEnabled[cmd] === undefined)
+        commandsEnabled[cmd] = true;
+      if (commandsEnabled[cmd])
         irc.emitter.on(cmd, plugin.commands[cmd]);
     }
     irc.plugins.push(plugin);
@@ -376,7 +376,7 @@ irc.emitter.on('disable', function (act) {
       for (var p in irc.plugins) {
         for (var cmd in irc.plugins[p].commands) {
           if (cmd === act.params[0]) {
-            pluginsEnabled[cmd] = false;
+            commandsEnabled[cmd] = false;
             irc.emitter.removeListener(cmd, irc.plugins[p].commands[cmd]);
             irc.privmsg(act.source, act.params[0] + ' disabled');
           }
@@ -393,8 +393,8 @@ irc.emitter.on('enable', function (act) {
     if (is_admin) {
       for (var p in irc.plugins) {
         for (var cmd in irc.plugins[p].commands) {
-          if (cmd === act.params[0] && pluginsEnabled[cmd] === false) {
-            pluginsEnabled[cmd] = true;
+          if (cmd === act.params[0] && commandsEnabled[cmd] === false) {
+            commandsEnabled[cmd] = true;
             irc.emitter.on(cmd, irc.plugins[p].commands[cmd]);
             irc.privmsg(act.source, act.params[0] + ' enabled');
           }

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -309,10 +309,7 @@ function unloadPlugin(filename) {
   var ppath = path.join(plugin_dir, filename);
   if (ppath.indexOf('.js', ppath.length - 3) === -1) {
     console.log('Invalid plugin file: ' + filename);
-  } else {
-    if (require.cache[ppath] === undefined)
-      return;
-
+  } else if (require.cache[ppath] !== undefined) {
     var plugin = require.cache[ppath].exports;
     delete require.cache[ppath];
 
@@ -321,6 +318,7 @@ function unloadPlugin(filename) {
         irc.plugins.pop(p);
     for (var command in plugin.commands)
       irc.emitter.removeListener(command, plugin.commands[command]);
+
     pluginData[plugin.name] = plugin.store;
   }
 }
@@ -331,12 +329,14 @@ function loadPlugin(filename) {
   } else {
     unloadPlugin(filename);
     var plugin = require(ppath);
+
     if (plugin.store === undefined)
       plugin.store = {};
     if (pluginData[plugin.name] === undefined)
       pluginData[plugin.name] = {};
     for (var valueName in pluginData[plugin.name])
       plugin.store[valueName] = pluginData[plugin.name][valueName];
+
     for (var cmd in plugin.commands) {
       if (commandsEnabled[cmd] === undefined)
         commandsEnabled[cmd] = true;

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -313,14 +313,14 @@ function unloadPlugin(filename) {
       return;
 
     var plugin = require.cache[ppath].exports;
+    delete require.cache[ppath];
 
     for (var p in irc.plugins)
       if (irc.plugins[p].name === plugin.name)
         irc.plugins.pop(p);
-
     for (var command in plugin.commands)
       irc.emitter.removeListener(command, plugin.commands[command]);
-    delete require.cache[ppath];
+    return plugin.store;
   }
 }
 function loadPlugin(filename) {
@@ -328,8 +328,12 @@ function loadPlugin(filename) {
   if (ppath.indexOf('.js', ppath.length - 3) === -1) {
     console.log('Invalid plugin file: ' + filename);
   } else {
-    unloadPlugin(filename);
+    var oldStore = unloadPlugin(filename);
     var plugin = require(ppath);
+    if (plugin.store === undefined)
+      plugin.store = {};
+    for (var valueName in oldStore)
+      plugin.store[valueName] = oldStore[valueName];
     for (var cmd in plugin.commands) {
       if (pluginsEnabled[cmd] === undefined)
         pluginsEnabled[cmd] = true;

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -303,6 +303,7 @@ irc.emitter.on('PRIVMSG', function (data) {
 
 global.irc = irc;
 irc.plugins = [];
+var pluginsEnabled = {};
 function unloadPlugin(filename) {
   var ppath = path.join(plugin_dir, filename);
   if (ppath.indexOf('.js', ppath.length - 3) === -1) {
@@ -318,7 +319,7 @@ function unloadPlugin(filename) {
         irc.plugins.pop(p);
 
     for (var command in plugin.commands)
-      irc.emitter.removeListener(command, plugin.commands[command].handler);
+      irc.emitter.removeListener(command, plugin.commands[command]);
     delete require.cache[ppath];
   }
 }
@@ -330,12 +331,10 @@ function loadPlugin(filename) {
     unloadPlugin(filename);
     var plugin = require(ppath);
     for (var cmd in plugin.commands) {
-      if (typeof plugin.commands[cmd] === 'function')
-        plugin.commands[cmd] = { 'handler': plugin.commands[cmd] };
-      if (plugin.commands[cmd].enabled === undefined)
-        plugin.commands[cmd].enabled = true;
-      if (plugin.commands[cmd].enabled)
-        irc.emitter.on(cmd, plugin.commands[cmd].handler);
+      if (pluginsEnabled[cmd] === undefined)
+        pluginsEnabled[cmd] = true;
+      if (pluginsEnabled[cmd])
+        irc.emitter.on(cmd, plugin.commands[cmd]);
     }
     irc.plugins.push(plugin);
   }
@@ -373,8 +372,8 @@ irc.emitter.on('disable', function (act) {
       for (var p in irc.plugins) {
         for (var cmd in irc.plugins[p].commands) {
           if (cmd === act.params[0]) {
-            irc.plugins[p].commands[cmd].enabled = false;
-            irc.emitter.removeListener(cmd, irc.plugins[p].commands[cmd].handler);
+            pluginsEnabled[cmd] = false;
+            irc.emitter.removeListener(cmd, irc.plugins[p].commands[cmd]);
             irc.privmsg(act.source, act.params[0] + ' disabled');
           }
         }
@@ -390,9 +389,9 @@ irc.emitter.on('enable', function (act) {
     if (is_admin) {
       for (var p in irc.plugins) {
         for (var cmd in irc.plugins[p].commands) {
-          if (cmd === act.params[0] && irc.plugins[p].commands[cmd].enabled === false) {
-            irc.plugins[p].commands[cmd].enabled = true;
-            irc.emitter.on(cmd, irc.plugins[p].commands[cmd].handler);
+          if (cmd === act.params[0] && pluginsEnabled[cmd] === false) {
+            pluginsEnabled[cmd] = true;
+            irc.emitter.on(cmd, irc.plugins[p].commands[cmd]);
             irc.privmsg(act.source, act.params[0] + ' enabled');
           }
         }

--- a/lib/ircnode.js
+++ b/lib/ircnode.js
@@ -303,19 +303,67 @@ irc.emitter.on('PRIVMSG', function (data) {
 
 global.irc = irc;
 irc.plugins = [];
+function unloadPlugin(filename) {
+  var ppath = path.join(plugin_dir, filename);
+  if (ppath.indexOf('.js', ppath.length - 3) === -1) {
+    console.log('Invalid plugin file: ' + filename);
+  } else {
+    if (require.cache[ppath] === undefined)
+      return;
+
+    var plugin = require.cache[ppath].exports;
+
+    for (var p in irc.plugins)
+      if (irc.plugins[p].name === plugin.name)
+        irc.plugins.pop(p);
+
+    for (var command in plugin.commands)
+      irc.emitter.removeListener(command, plugin.commands[command].handler);
+    delete require.cache[ppath];
+  }
+}
+function loadPlugin(filename) {
+  var ppath = path.join(plugin_dir, filename);
+  if (ppath.indexOf('.js', ppath.length - 3) === -1) {
+    console.log('Invalid plugin file: ' + filename);
+  } else {
+    unloadPlugin(filename);
+    var plugin = require(ppath);
+    for (var cmd in plugin.commands) {
+      if (typeof plugin.commands[cmd] === 'function')
+        plugin.commands[cmd] = { 'handler': plugin.commands[cmd] };
+      if (plugin.commands[cmd].enabled === undefined)
+        plugin.commands[cmd].enabled = true;
+      if (plugin.commands[cmd].enabled)
+        irc.emitter.on(cmd, plugin.commands[cmd].handler);
+    }
+    irc.plugins.push(plugin);
+  }
+}
 fs.readdir(plugin_dir, function (err, files) {
   for (var i = 0, len = files.length; i < len; i += 1) {
-    var ppath = path.join(plugin_dir, files[i]);
-    if (ppath.indexOf('.js', ppath.length - 3) === -1) {
-      console.log('Invalid plugin file: ' + files[i]);
-    } else {
-      var plugin = require(ppath);
-      plugin.enabled = true;
-      irc.plugins.push(plugin);
-      for (var e in plugin.name) {
-        irc.emitter.on(plugin.name[e], plugin.handler[e]);
+    loadPlugin(files[i]);
+  }
+});
+fs.watch(plugin_dir, { persistent: false }, function (event, filename) {
+  if (!filename) {
+    console.log('Filename of modified plugin not provided');
+  } else if (event === 'rename') {
+    fs.exists(path.join(plugin_dir, filename), function (exists) {
+      if (exists) {
+        if (irc.debug)
+          console.log('Plugin file created: ' + filename);
+        loadPlugin(filename);
+      } else {
+        if (irc.debug)
+          console.log('Plugin file deleted: ' + filename);
+        unloadPlugin(filename);
       }
-    }
+    });
+  } else {
+    if (irc.debug)
+      console.log('Plugin file modified: ' + filename);
+    loadPlugin(filename);
   }
 });
 
@@ -323,10 +371,10 @@ irc.emitter.on('disable', function (act) {
   irc.check_level(act.nick, act.host, 'admin', function (is_admin) {
     if (is_admin) {
       for (var p in irc.plugins) {
-        for (var e in irc.plugins[p].name) {
-          if (irc.plugins[p].name[e] === act.params[0]) {
-            irc.plugins[p].enabled = false;
-            irc.emitter.removeListener(irc.plugins[p].name[e], irc.plugins[p].handler[e]);
+        for (var cmd in irc.plugins[p].commands) {
+          if (cmd === act.params[0]) {
+            irc.plugins[p].commands[cmd].enabled = false;
+            irc.emitter.removeListener(cmd, irc.plugins[p].commands[cmd].handler);
             irc.privmsg(act.source, act.params[0] + ' disabled');
           }
         }
@@ -341,11 +389,10 @@ irc.emitter.on('enable', function (act) {
   irc.check_level(act.nick, act.host, 'admin', function (is_admin) {
     if (is_admin) {
       for (var p in irc.plugins) {
-        for (var e in irc.plugins[p].name) {
-          if (irc.plugins[p].name[e] === act.params[0] &&
-              irc.plugins[p].enabled === false) {
-            irc.plugins[p].enabled = true;
-            irc.emitter.on(irc.plugins[p].name[e], irc.plugins[p].handler[e]);
+        for (var cmd in irc.plugins[p].commands) {
+          if (cmd === act.params[0] && irc.plugins[p].commands[cmd].enabled === false) {
+            irc.plugins[p].commands[cmd].enabled = true;
+            irc.emitter.on(cmd, irc.plugins[p].commands[cmd].handler);
             irc.privmsg(act.source, act.params[0] + ' enabled');
           }
         }


### PR DESCRIPTION
Adds plugin reloading on plugin file change and persistent storage for storing data when reloading. Closes #9. 

``` javascript
// Simple example plugin to demonstrate new functions.

var irc = global.irc;

var cmd_handler = function (act) {
  exports.store.countVar++;
  irc.privmsg(act.source, 'Hi, #' + exports.store.countVar + '!');
};

// The name of plugin. Associated with plugin's data.
exports.name = 'hello';
// All commands and their respective handlers.
exports.commands = { 'hello': cmd_handler };
// Plugin's data which needs to be retained.
exports.store = { 'countVar': 0 };
```
